### PR TITLE
COOPR-604: CLI: help command output should be more readable.

### DIFF
--- a/common-cli/src/main/java/co/cask/common/cli/util/DefaultHelpFormatter.java
+++ b/common-cli/src/main/java/co/cask/common/cli/util/DefaultHelpFormatter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2012-2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.common.cli.util;
+
+import co.cask.common.cli.Command;
+import co.cask.common.cli.command.HelpCommand;
+
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Utility interface for printing the {@link HelpCommand} output.
+ */
+public class DefaultHelpFormatter implements HelpFormatter {
+
+  public void print(Iterable<Command> commands, PrintStream printStream) {
+    List<Command> sortedCommands = new LinkedList<Command>();
+
+    for (Command command : commands) {
+      sortedCommands.add(command);
+    }
+
+    Collections.sort(sortedCommands, new Comparator<Command>() {
+      @Override
+      public int compare(Command o1, Command o2) {
+        return o1.getPattern().compareTo(o2.getPattern());
+      }
+    });
+
+    printStream.println("Available commands:");
+
+    String previousCommandName = "";
+    for (Command command : sortedCommands) {
+      String[] commandName = command.getPattern().split(" ", 2);
+      if (previousCommandName.compareTo(commandName[0]) != 0) {
+        previousCommandName = commandName[0];
+        printStream.println(String.format("%s", previousCommandName));
+      }
+
+      printStream.println(String.format("  • %s: %s", command.getPattern(), command.getDescription()));
+    }
+  }
+}

--- a/common-cli/src/main/java/co/cask/common/cli/util/DefaultHelpFormatter.java
+++ b/common-cli/src/main/java/co/cask/common/cli/util/DefaultHelpFormatter.java
@@ -54,7 +54,7 @@ public class DefaultHelpFormatter implements HelpFormatter {
         printStream.println(String.format("%s", previousCommandName));
       }
 
-      printStream.println(String.format("  • %s: %s", command.getPattern(), command.getDescription()));
+      printStream.println(String.format("  * %s: %s", command.getPattern(), command.getDescription()));
     }
   }
 }

--- a/common-cli/src/main/java/co/cask/common/cli/util/HelpFormatter.java
+++ b/common-cli/src/main/java/co/cask/common/cli/util/HelpFormatter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2012-2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.common.cli.util;
+
+import co.cask.common.cli.Command;
+import co.cask.common.cli.command.HelpCommand;
+
+import java.io.PrintStream;
+
+/**
+ * Utility interface for printing the {@link HelpCommand} output.
+ */
+public interface HelpFormatter {
+
+  public void print(Iterable<Command> commands, PrintStream printStream);
+}

--- a/common-cli/src/test/java/co/cask/common/cli/command/HelpCommandTest.java
+++ b/common-cli/src/test/java/co/cask/common/cli/command/HelpCommandTest.java
@@ -143,7 +143,7 @@ public class HelpCommandTest {
       } else if (command == TEST_COMMAND3) {
         builder.append("list").append(System.getProperty("line.separator"));
       }
-      builder.append(String.format("  • %s: %s", command.getPattern(), command.getDescription()))
+      builder.append(String.format("  * %s: %s", command.getPattern(), command.getDescription()))
         .append(System.getProperty("line.separator"));
     }
     builder.append(System.getProperty("line.separator"));

--- a/common-cli/src/test/java/co/cask/common/cli/command/HelpCommandTest.java
+++ b/common-cli/src/test/java/co/cask/common/cli/command/HelpCommandTest.java
@@ -35,10 +35,10 @@ import java.io.PrintStream;
 public class HelpCommandTest {
 
   private static final String HELP_HEADER = "Help header";
-  private static final String TEST_COMMAND1_PATTERN = "get something <param>";
-  private static final String TEST_COMMAND1_DESCRIPTION = "Test command 1 description";
-  private static final String TEST_COMMAND2_PATTERN = "get another thing";
-  private static final String TEST_COMMAND2_DESCRIPTION = "Test command 2 description";
+  private static final String TEST_COMMAND1_PATTERN = "get another thing";
+  private static final String TEST_COMMAND1_DESCRIPTION = "Test command 2 description";
+  private static final String TEST_COMMAND2_PATTERN = "get something <param>";
+  private static final String TEST_COMMAND2_DESCRIPTION = "Test command 1 description";
   private static final String TEST_COMMAND3_PATTERN = "list of something <param> [<optional>]";
   private static final String TEST_COMMAND3_DESCRIPTION = "Test command 3 description";
   private static final Command TEST_COMMAND1 = new Command() {
@@ -103,8 +103,8 @@ public class HelpCommandTest {
   public void helpCommandTest() throws Exception {
     CommandMatch match = TEST_SET.findMatch("help");
     testCommandOutput(match.getCommand(), match.getArguments(), createExpectedOutput(HELP_HEADER,
-                                                                                     HELP_COMMAND, TEST_COMMAND1,
-                                                                                     TEST_COMMAND2, TEST_COMMAND3));
+                                                                                     TEST_COMMAND1, TEST_COMMAND2,
+                                                                                     HELP_COMMAND, TEST_COMMAND3));
   }
 
   @Test
@@ -136,7 +136,14 @@ public class HelpCommandTest {
     }
     builder.append("Available commands:").append(System.getProperty("line.separator"));
     for (Command command : commands) {
-      builder.append(String.format("%s: %s", command.getPattern(), command.getDescription()))
+      if (command == HELP_COMMAND) {
+        builder.append("help").append(System.getProperty("line.separator"));
+      } else if (command == TEST_COMMAND1) {
+        builder.append("get").append(System.getProperty("line.separator"));
+      } else if (command == TEST_COMMAND3) {
+        builder.append("list").append(System.getProperty("line.separator"));
+      }
+      builder.append(String.format("  • %s: %s", command.getPattern(), command.getDescription()))
         .append(System.getProperty("line.separator"));
     }
     builder.append(System.getProperty("line.separator"));


### PR DESCRIPTION
@jwang47 I have added the HelpFormatter interface for custom help output, and also implemented the DefaultHelpFormatter for output by default.

Please see updated COOPR help output below:

```
coopr (http://localhost:55054)> help 
COOPR_HOST=localhost
COOPR_USER=admin
COOPR_TENANT=superadmin

Available commands:
add
  • add services <services> on cluster <cluster-id>: Adds one or more services to a cluster
connect
  • connect to <host> as <user> <tenant> [using port <port>] [with ssl <enabled/disabled>]: Connects to a Coopr instance
create
  • create cluster <name> with template <template> of size <size> [using settings <settings>]: Creates a cluster
delete
  • delete cluster <cluster-id> [with provider fields <provider-fields>]: Deletes a cluster
  • delete hardware type <name>: Deletes a hardware type
  • delete image type <name>: Deletes an image type
  • delete provider <name>: Deletes a provider
  • delete resource from automator <automator-id> of type <resource-type> and name <resource-name> and version <resource-version>: Delete a specific version of an automator type resource
  • delete resource from provider <provider-id> of type <resource-type> and name <resource-name> and version <resource-version>: Delete a specific version of a provider type resource
  • delete service <name>: Deletes a service
  • delete template <name>: Deletes a cluster template
  • delete tenant <name>: Deletes a tenant
exit
  • exit: Exits the command-line interface
get
  • get automatortype <automator-id>: Get automator type by id
  • get cluster <cluster-id>: Gets the cluster
  • get cluster-config <cluster-id>: Gets the cluster config
  • get cluster-status <cluster-id>: Gets the cluster status
  • get hardware type <name>: Gets the hardware type
  • get image type <name>: Gets the image type
  • get provider <name>: Gets the provider
  • get providertype <provider-id>: Get provider type
  • get provisioner <provisioner-id>: Gets the provisioner
  • get service <name>: Gets the service
  • get template <name>: Gets the cluster template
  • get tenant <name>: Gets the tenant
help
  • help [<command>]: Prints usage information and description of commands
list
  • list all automatortypes: Lists all automator types
  • list all providertypes: Lists all provider types
  • list clusters: Lists all clusters
  • list hardware types: Lists all cluster hardware types
  • list image types: Lists all image types
  • list providers: Lists all providers
  • list provisioners: Lists all provisioners
  • list resources from automator <automator-id> of type <resource-type> [and status <status>]: Lists automator type resources.
  • list resources from provider <provider-id> of type <resource-type> [and status <status>]: Lists provider type resources.
  • list services: Lists all services
  • list services <cluster-id>: Lists all cluster services
  • list templates: Lists all cluster templates
  • list tenants: Lists all tenants
quit
  • quit: Quits the command-line interface
recall
  • recall resource from automator <automator-id> of type <resource-type> and name <resource-name> and version <resource-version>: Recall a specific version of an automator type resource
  • recall resource from provider <provider-id> of type <resource-type> and name <resource-name> and version <resource-version>: Recall a specific version of a provider type resource.
restart
  • restart service <service-id> on cluster <cluster-id> [with provider fields <provider-fields>]: Restarts service on cluster
set
  • set config <cluster-config> for cluster <cluster-id>: Sets the cluster config
  • set expire time <expire-time> for cluster <cluster-id>: Sets the cluster expire time
stage
  • stage resource from automator <automator-id> of type <resource-type> and name <resource-name> and version <resource-version>: Stage a specific version of an automator type resource
  • stage resource from provider <provider-id> of type <resource-type> and name <resource-name> and version <resource-version>: Stage a specific version of a provider type resource
start
  • start service <service-id> on cluster <cluster-id> [with provider fields <provider-fields>]: Starts service on cluster
stop
  • stop service <service-id> on cluster <cluster-id> [with provider fields <provider-fields>]: Stops service on cluster
sync
  • sync cluster template <cluster-id>: Synchronize the cluster template
  • sync resources: Synchronize resources
```
