### PR TITLE
COOPR-604: CLI: help command output should be more readable.

### DIFF
--- a/common-cli/src/main/java/co/cask/common/cli/command/ExitCommand.java
+++ b/common-cli/src/main/java/co/cask/common/cli/command/ExitCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,6 +28,6 @@ public class ExitCommand extends AbstractExitCommand {
 
   @Override
   public String getDescription() {
-    return "Exits the command-line interface";
+    return "Exits the command line interface";
   }
 }

--- a/common-cli/src/main/java/co/cask/common/cli/command/HelpCommand.java
+++ b/common-cli/src/main/java/co/cask/common/cli/command/HelpCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -93,6 +93,6 @@ public class HelpCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Prints usage information and description of commands";
+    return "Prints usage information or description of a command";
   }
 }

--- a/common-cli/src/main/java/co/cask/common/cli/command/QuitCommand.java
+++ b/common-cli/src/main/java/co/cask/common/cli/command/QuitCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,6 +28,6 @@ public class QuitCommand extends AbstractExitCommand {
 
   @Override
   public String getDescription() {
-    return "Quits the command-line interface";
+    return "Quits the command line interface";
   }
 }

--- a/common-cli/src/main/java/co/cask/common/cli/util/DefaultHelpFormatter.java
+++ b/common-cli/src/main/java/co/cask/common/cli/util/DefaultHelpFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -30,6 +30,8 @@ import java.util.List;
  */
 public class DefaultHelpFormatter implements HelpFormatter {
 
+  private static final int MAX_LINE_LEN = 120;
+
   public void print(Iterable<Command> commands, PrintStream printStream) {
     List<Command> sortedCommands = new LinkedList<Command>();
 
@@ -54,7 +56,13 @@ public class DefaultHelpFormatter implements HelpFormatter {
         printStream.println(String.format("%s", previousCommandName));
       }
 
-      printStream.println(String.format("  * %s: %s", command.getPattern(), command.getDescription()));
+      String pattern = command.getPattern();
+      String description = command.getDescription();
+      if (pattern.length() + description.length() > MAX_LINE_LEN) {
+        printStream.println(String.format("  * %s:\n      %s", pattern, description));
+      } else {
+        printStream.println(String.format("  * %s: %s", pattern, description));
+      }
     }
   }
 }


### PR DESCRIPTION
@awholegunch I have updated descriptions of the common commands as you mentioned in the ticket comment. Also split long lines (more than 120 symbols) by pattern and description.

Please see current help command output in the https://github.com/caskdata/coopr/pull/878.
