### PR TITLE
Only use fixed length stream mode if the body length exceed some thresho...

### DIFF
--- a/common-http/src/main/java/co/cask/common/http/HttpRequestConfig.java
+++ b/common-http/src/main/java/co/cask/common/http/HttpRequestConfig.java
@@ -15,25 +15,27 @@
  */
 package co.cask.common.http;
 
+import java.net.HttpURLConnection;
+
 /**
  * Configuration per HTTP request executed by {@link HttpRequests}.
  */
 public class HttpRequestConfig {
 
   public static final HttpRequestConfig DEFAULT = new HttpRequestConfig(15000, 15000);
+  private static final int DEFAULT_FIXED_LENGTH_STREAMING_THRESHOLD = 256 * 1024; // 256K
 
   private final int connectTimeout;
   private final int readTimeout;
   private final boolean verifySSLCert;
+  private final int fixedLengthStreamingThreshold;
 
   /**
    * @param connectTimeout Connect timeout, in milliseconds. See {@link java.net.URLConnection#getConnectTimeout()}.
    * @param readTimeout Read timeout, in milliseconds. See {@link java.net.URLConnection#getReadTimeout()}.
    */
   public HttpRequestConfig(int connectTimeout, int readTimeout) {
-    this.connectTimeout = connectTimeout;
-    this.readTimeout = readTimeout;
-    this.verifySSLCert = true;
+    this(connectTimeout, readTimeout, true);
   }
 
   /**
@@ -43,9 +45,23 @@ public class HttpRequestConfig {
    *                      verified.
    */
   public HttpRequestConfig(int connectTimeout, int readTimeout, boolean verifySSLCert) {
+    this(connectTimeout, readTimeout, verifySSLCert, DEFAULT_FIXED_LENGTH_STREAMING_THRESHOLD);
+  }
+
+  /**
+   * @param connectTimeout Connect timeout, in milliseconds. See {@link java.net.URLConnection#getConnectTimeout()}.
+   * @param readTimeout Read timeout, in milliseconds. See {@link java.net.URLConnection#getReadTimeout()}.
+   * @param verifySSLCert false, to disable certificate verifying in SSL connections. By default SSL certificate is
+   *                      verified.
+   * @param fixedLengthStreamingThreshold number of bytes in the request body to use fix length request mode. See
+   *                                  {@link HttpURLConnection#setFixedLengthStreamingMode(int)}.
+   */
+  public HttpRequestConfig(int connectTimeout, int readTimeout,
+                           boolean verifySSLCert, int fixedLengthStreamingThreshold) {
     this.connectTimeout = connectTimeout;
     this.readTimeout = readTimeout;
     this.verifySSLCert = verifySSLCert;
+    this.fixedLengthStreamingThreshold = fixedLengthStreamingThreshold;
   }
 
   public int getConnectTimeout() {
@@ -58,5 +74,9 @@ public class HttpRequestConfig {
 
   public boolean isVerifySSLCert() {
     return verifySSLCert;
+  }
+
+  public int getFixedLengthStreamingThreshold() {
+    return fixedLengthStreamingThreshold;
   }
 }

--- a/common-http/src/main/java/co/cask/common/http/HttpRequests.java
+++ b/common-http/src/main/java/co/cask/common/http/HttpRequests.java
@@ -70,7 +70,7 @@ public final class HttpRequests {
     conn.setConnectTimeout(requestConfig.getConnectTimeout());
 
     Multimap<String, String> headers = request.getHeaders();
-    if (headers != null) {
+    if (headers != null && !headers.isEmpty()) {
       for (Map.Entry<String, String> header : headers.entries()) {
         conn.setRequestProperty(header.getKey(), header.getValue());
       }
@@ -82,7 +82,9 @@ public final class HttpRequests {
       Long bodyLength = request.getBodyLength();
       if (bodyLength != null) {
         // use intValue to support 1.6
-        conn.setFixedLengthStreamingMode(bodyLength.intValue());
+        if (bodyLength > requestConfig.getFixedLengthStreamingThreshold()) {
+          conn.setFixedLengthStreamingMode(bodyLength.intValue());
+        }
       } else {
         conn.setChunkedStreamingMode(0);
       }


### PR DESCRIPTION
...ld.
- Apparently default buffer mode is about 5x faster than fixed length mode for small request body.
