### PR TITLE
CDAP-4470 HttpRequests to reuse connections.

### DIFF
--- a/common-core/src/main/java/co/cask/common/Networks.java
+++ b/common-core/src/main/java/co/cask/common/Networks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.common;
 
 import com.google.common.base.Charsets;
@@ -54,11 +55,8 @@ public final class Networks {
    */
   public static int getRandomPort() {
     try {
-      ServerSocket socket = new ServerSocket(0);
-      try {
+      try (ServerSocket socket = new ServerSocket(0)) {
         return socket.getLocalPort();
-      } finally {
-        socket.close();
       }
     } catch (IOException e) {
       return -1;

--- a/common-http/src/main/java/co/cask/common/http/HttpRequests.java
+++ b/common-http/src/main/java/co/cask/common/http/HttpRequests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.common.http;
 
 import com.google.common.collect.Multimap;
@@ -104,18 +105,17 @@ public final class HttpRequests {
 
     try {
       if (bodySrc != null) {
-        OutputStream os = conn.getOutputStream();
-        try {
+        try (OutputStream os = conn.getOutputStream()) {
           ByteStreams.copy(bodySrc, os);
-        } finally {
-          os.close();
         }
       }
 
       try {
         if (isSuccessful(conn.getResponseCode())) {
-          return new HttpResponse(conn.getResponseCode(), conn.getResponseMessage(),
-                                  ByteStreams.toByteArray(conn.getInputStream()), conn.getHeaderFields());
+          try (InputStream inputStream = conn.getInputStream()) {
+            return new HttpResponse(conn.getResponseCode(), conn.getResponseMessage(),
+                                    ByteStreams.toByteArray(inputStream), conn.getHeaderFields());
+          }
         }
       } catch (FileNotFoundException e) {
         // Server returns 404. Hence handle as error flow below. Intentional having empty catch block.

--- a/common-http/src/test/java/co/cask/common/http/HttpRequestsTest.java
+++ b/common-http/src/test/java/co/cask/common/http/HttpRequestsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,10 +16,6 @@
 
 package co.cask.common.http;
 
-import co.cask.http.NettyHttpService;
-import com.google.common.base.Objects;
-import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.AbstractIdleService;
 import org.junit.After;
 import org.junit.Before;
 
@@ -35,8 +31,8 @@ public class HttpRequestsTest extends HttpRequestsTestBase {
   private static TestHttpService httpService;
 
   @Before
-  public void setUp() {
-    httpService = new TestHttpService();
+  public void setUp() throws Exception {
+    httpService = new TestHttpService(false);
     httpService.startAndWait();
   }
 
@@ -56,39 +52,8 @@ public class HttpRequestsTest extends HttpRequestsTestBase {
     return HttpRequestConfig.DEFAULT;
   }
 
-  public static final class TestHttpService extends AbstractIdleService {
-
-    private final NettyHttpService httpService;
-
-    public TestHttpService() {
-      this.httpService = NettyHttpService.builder()
-        .setHost("localhost")
-        .addHttpHandlers(Sets.newHashSet(new HttpRequestsTestBase.TestHandler()))
-        .setWorkerThreadPoolSize(10)
-        .setExecThreadPoolSize(10)
-        .setConnectionBacklog(20000)
-        .build();
-    }
-
-    public InetSocketAddress getBindAddress() {
-      return httpService.getBindAddress();
-    }
-
-    @Override
-    protected void startUp() throws Exception {
-      httpService.startAndWait();
-    }
-
-    @Override
-    protected void shutDown() throws Exception {
-      httpService.stopAndWait();
-    }
-
-    @Override
-    public String toString() {
-      return Objects.toStringHelper(this)
-        .add("bindAddress", httpService.getBindAddress())
-        .toString();
-    }
+  @Override
+  protected int getNumConnectionsOpened() {
+    return httpService.getNumConnectionsOpened();
   }
 }

--- a/common-http/src/test/java/co/cask/common/http/HttpRequestsTestBase.java
+++ b/common-http/src/test/java/co/cask/common/http/HttpRequestsTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -50,17 +50,23 @@ public abstract class HttpRequestsTestBase {
 
   protected abstract HttpRequestConfig getHttpRequestsConfig();
 
+  protected abstract int getNumConnectionsOpened();
+
   @Test
   public void testHttpStatus() throws Exception {
     testGet("/fake/fake", only(404), only("Not Found"),
             only("Problem accessing: /fake/fake. Reason: Not Found"), any());
     testGet("/api/testOkWithResponse", only(200), any(), only("Great response"), any());
+
+    int numConnectionsOpened = getNumConnectionsOpened();
     testGet("/api/testOkWithResponse201", only(201), any(), only("Great response 201"), any());
     testGet("/api/testOkWithResponse202", only(202), any(), only("Great response 202"), any());
     testGet("/api/testOkWithResponse203", only(203), any(), only("Great response 203"), any());
     testGet("/api/testOkWithResponse204", only(204), any(), only(""), any());
     testGet("/api/testOkWithResponse205", only(205), any(), only("Great response 205"), any());
     testGet("/api/testOkWithResponse206", only(206), any(), only("Great response 206"), any());
+    // the preceding sequence of calls should reuse the same connection
+    Assert.assertEquals(numConnectionsOpened, getNumConnectionsOpened());
 
     // Expected headers for a request
     Multimap<String, String> expectedHeaders = ArrayListMultimap.create();

--- a/common-http/src/test/java/co/cask/common/http/HttpsRequestsTest.java
+++ b/common-http/src/test/java/co/cask/common/http/HttpsRequestsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,30 +16,23 @@
 
 package co.cask.common.http;
 
-import co.cask.http.NettyHttpService;
-import com.google.common.base.Objects;
-import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.AbstractIdleService;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 
-import java.io.File;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 
 /**
  * Test for {@link HttpRequests} against HTTPS.
  */
 public class HttpsRequestsTest extends HttpRequestsTestBase {
 
-  private static TestHttpsService httpsService;
+  private static TestHttpService httpsService;
 
   @Before
   public void setUp() throws Exception {
-    httpsService = new TestHttpsService();
+    httpsService = new TestHttpService(true);
     httpsService.startAndWait();
   }
 
@@ -59,43 +52,8 @@ public class HttpsRequestsTest extends HttpRequestsTestBase {
     return new HttpRequestConfig(0, 0, false);
   }
 
-  public static final class TestHttpsService extends AbstractIdleService {
-
-    private final NettyHttpService httpService;
-
-    public TestHttpsService() throws URISyntaxException {
-      URL keystore = getClass().getClassLoader().getResource("cert.jks");
-      Assert.assertNotNull(keystore);
-
-      this.httpService = NettyHttpService.builder()
-        .setHost("localhost")
-        .addHttpHandlers(Sets.newHashSet(new TestHandler()))
-        .setWorkerThreadPoolSize(10)
-        .setExecThreadPoolSize(10)
-        .setConnectionBacklog(20000)
-        .enableSSL(new File(keystore.toURI()), "secret", "secret")
-        .build();
-    }
-
-    public InetSocketAddress getBindAddress() {
-      return httpService.getBindAddress();
-    }
-
-    @Override
-    protected void startUp() throws Exception {
-      httpService.startAndWait();
-    }
-
-    @Override
-    protected void shutDown() throws Exception {
-      httpService.stopAndWait();
-    }
-
-    @Override
-    public String toString() {
-      return Objects.toStringHelper(this)
-        .add("bindAddress", httpService.getBindAddress())
-        .toString();
-    }
+  @Override
+  protected int getNumConnectionsOpened() {
+    return httpsService.getNumConnectionsOpened();
   }
 }

--- a/common-http/src/test/java/co/cask/common/http/TestHttpService.java
+++ b/common-http/src/test/java/co/cask/common/http/TestHttpService.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.common.http;
+
+import co.cask.http.NettyHttpService;
+import com.google.common.base.Function;
+import com.google.common.base.Objects;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AbstractIdleService;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.SimpleChannelHandler;
+import org.junit.Assert;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+/**
+ * Service for testing {@link HttpRequests}.
+ */
+public final class TestHttpService extends AbstractIdleService {
+
+  private final NettyHttpService httpService;
+  private final AtomicInteger numConnectionsOpened = new AtomicInteger(0);
+
+  public TestHttpService(boolean sslEnabled) throws URISyntaxException {
+    NettyHttpService.Builder builder = NettyHttpService.builder();
+    builder
+      .setHost("localhost")
+      .addHttpHandlers(Sets.newHashSet(new HttpRequestsTestBase.TestHandler()))
+      .modifyChannelPipeline(new Function<ChannelPipeline, ChannelPipeline>() {
+        @Nullable
+        @Override
+        public ChannelPipeline apply(ChannelPipeline input) {
+          input.addLast("connection-counter", new SimpleChannelHandler() {
+            @Override
+            public void channelOpen(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception {
+              numConnectionsOpened.incrementAndGet();
+              super.channelOpen(ctx, e);
+            }
+          });
+          return input;
+        }
+      })
+      .setWorkerThreadPoolSize(10)
+      .setExecThreadPoolSize(10)
+      .setConnectionBacklog(20000);
+
+    if (sslEnabled) {
+      URL keystore = getClass().getClassLoader().getResource("cert.jks");
+      Assert.assertNotNull(keystore);
+      builder.enableSSL(new File(keystore.toURI()), "secret", "secret");
+    }
+
+    this.httpService = builder.build();
+  }
+
+  public InetSocketAddress getBindAddress() {
+    return httpService.getBindAddress();
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    httpService.startAndWait();
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    httpService.stopAndWait();
+  }
+
+  public int getNumConnectionsOpened() {
+    return numConnectionsOpened.get();
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("bindAddress", httpService.getBindAddress())
+      .toString();
+  }
+}

--- a/common-security/pom.xml
+++ b/common-security/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright © 2014 Cask Data, Inc.
+Copyright © 2014-2016 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
@@ -14,6 +14,7 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
 -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -151,13 +152,13 @@ the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
+      <groupId>co.cask.hbase</groupId>
       <artifactId>hbase</artifactId>
       <scope>test</scope>
     </dependency>

--- a/common-security/src/main/java/co/cask/common/security/tools/SSLHandlerFactory.java
+++ b/common-security/src/main/java/co/cask/common/security/tools/SSLHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -49,11 +49,8 @@ public class SSLHandlerFactory {
 
     try {
       KeyStore ks = KeyStore.getInstance(keyStoreType);
-      InputStream inputStream = new FileInputStream(keyStore);
-      try {
+      try (InputStream inputStream = new FileInputStream(keyStore)) {
         ks.load(inputStream, keyStorePassword.toCharArray());
-      } finally {
-        inputStream.close();
       }
       // Set up key manager factory to use our key store
       KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright © 2014 Cask Data, Inc.
+Copyright © 2014-2016 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
@@ -14,6 +14,7 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
 -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -437,8 +438,8 @@ the License.
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.1</version>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.7</source>
+            <target>1.7</target>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -60,10 +60,6 @@ the License.
       <id>sonatype</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
-    <repository>
-      <id>continuuity-public</id>
-      <url>https://repository.continuuity.com/content/repositories/public</url>
-    </repository>
   </repositories>
 
   <distributionManagement>
@@ -99,7 +95,7 @@ the License.
     <jetty8.version>8.1.15.v20140411</jetty8.version>
     <jline.version>2.12</jline.version>
     <junit.version>4.11</junit.version>
-    <hbase94.version>0.94.6.1.continuuity</hbase94.version>
+    <hbase94.version>0.94.6.1.cask</hbase94.version>
     <mockito.version>1.9.5</mockito.version>
     <logback.version>1.0.9</logback.version>
     <servlet.api.version>3.0.1</servlet.api.version>
@@ -285,7 +281,7 @@ the License.
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.hbase</groupId>
+        <groupId>co.cask.hbase</groupId>
         <artifactId>hbase</artifactId>
         <version>${hbase94.version}</version>
         <exclusions>
@@ -340,7 +336,7 @@ the License.
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.hbase</groupId>
+        <groupId>co.cask.hbase</groupId>
         <artifactId>hbase</artifactId>
         <classifier>tests</classifier>
         <version>${hbase94.version}</version>


### PR DESCRIPTION
Update HttpRequests.java to reuse connections across calls to its execute method.
The updated test case in this PR checks that the connection is reused.

https://issues.cask.co/browse/CDAP-4470
