### PR TITLE
Remove usages of Guava's InputSupplier class, which has been removed in later versions of Guava.

### DIFF
--- a/common-http/src/main/java/co/cask/common/http/HttpRequests.java
+++ b/common-http/src/main/java/co/cask/common/http/HttpRequests.java
@@ -16,9 +16,9 @@
 
 package co.cask.common.http;
 
+import co.cask.common.ContentProvider;
 import com.google.common.collect.Multimap;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.InputSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +77,7 @@ public final class HttpRequests {
       }
     }
 
-    InputSupplier<? extends InputStream> bodySrc = request.getBody();
+    ContentProvider<? extends InputStream> bodySrc = request.getBody();
     if (bodySrc != null) {
       conn.setDoOutput(true);
       Long bodyLength = request.getBodyLength();
@@ -105,8 +105,8 @@ public final class HttpRequests {
 
     try {
       if (bodySrc != null) {
-        try (OutputStream os = conn.getOutputStream()) {
-          ByteStreams.copy(bodySrc, os);
+        try (InputStream input = bodySrc.getInput(); OutputStream os = conn.getOutputStream()) {
+          ByteStreams.copy(input, os);
         }
       }
 

--- a/common-io/src/main/java/co/cask/common/ContentProvider.java
+++ b/common-io/src/main/java/co/cask/common/ContentProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A factory for readable streams of bytes or characters.
+ *
+ * @param <T> The type of input
+ */
+public interface ContentProvider<T extends InputStream> {
+
+  /**
+   * Returns an object that encapsulates a readable resource.
+   */
+  T getInput() throws IOException;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -432,10 +432,10 @@ the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
+          <version>3.7.0</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Remove usages of Guava's InputSupplier class, which has been removed in later versions of Guava.
Also upgrade to java 1.8.