### PR TITLE
Don't use Closeables.closeQuiently(inputStream)

### DIFF
--- a/common-http/src/main/java/io/cdap/common/http/HttpResponse.java
+++ b/common-http/src/main/java/io/cdap/common/http/HttpResponse.java
@@ -20,7 +20,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.Closeables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,9 +142,20 @@ public class HttpResponse {
     } catch (IOException e) {
       throw Throwables.propagate(e);
     } finally {
-      Closeables.closeQuietly(inputStream);
+      closeQuietly(inputStream);
       inputStream = null;
       conn.disconnect();
+    }
+  }
+
+  private void closeQuietly(@Nullable InputStream inputStream) {
+    if (inputStream == null) {
+      return;
+    }
+    try {
+      inputStream.close();
+    } catch (IOException e) {
+      LOG.warn("Failed to close input stream", e);
     }
   }
 


### PR DESCRIPTION
Looks like cdap-integration-tests repo is using guava [20](https://github.com/cdapio/cdap-integration-tests/blob/develop/pom.xml#L110), which causes this failure:
```
java.lang.NoSuchMethodError: com.google.common.io.Closeables.closeQuietly(Ljava/io/Closeable;)V
	at io.cdap.common.http.HttpResponse.getResponseBodyFromStream(HttpResponse.java:146)
	at io.cdap.common.http.HttpResponse.<init>(HttpResponse.java:66)
	at io.cdap.common.http.HttpRequests.execute(HttpRequests.java:73)
	at io.cdap.cdap.client.util.RESTClient.execute(RESTClient.java:107)
	at io.cdap.cdap.client.util.RESTClient.execute(RESTClient.java:74)
	at io.cdap.cdap.client.MonitorClient.getAllSystemServiceStatus(MonitorClient.java:138)
	at io.cdap.cdap.client.MonitorClient.allSystemServicesOk(MonitorClient.java:148)
	at io.cdap.cdap.test.IntegrationTestBase$1.call(IntegrationTestBase.java:161)
	at io.cdap.cdap.test.IntegrationTestBase$1.call(IntegrationTestBase.java:157)
	at io.cdap.cdap.test.IntegrationTestBase.checkServicesWithRetry(IntegrationTestBase.java:248)
	at io.cdap.cdap.test.IntegrationTestBase.checkSystemServices(IntegrationTestBase.java:190)
	at io.cdap.cdap.test.IntegrationTestBase.setUp(IntegrationTestBase.java:97)
```