### PR TITLE
Fix security vulnerabilities due to netty dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ the License.
     <logback.version>1.0.9</logback.version>
     <servlet.api.version>3.0.1</servlet.api.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <netty.version>4.1.16.Final</netty.version>
+    <netty.version>4.1.71.Final</netty.version>
     <twill.version>0.14.0</twill.version>
     <unboundid.version>2.3.6</unboundid.version>
     <resteasy.version>3.0.8.Final</resteasy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ the License.
     <logback.version>1.0.9</logback.version>
     <servlet.api.version>3.0.1</servlet.api.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <netty.version>4.1.71.Final</netty.version>
+    <netty.version>4.1.75.Final</netty.version>
     <twill.version>0.14.0</twill.version>
     <unboundid.version>2.3.6</unboundid.version>
     <resteasy.version>3.0.8.Final</resteasy.version>


### PR DESCRIPTION
## Vulnerability Details:
CVE-2019-20444
CVE-2019-20445
CVE-2015-2156
CVE-2019-16869
CVE-2019-9518
CVE-2020-7238
CVE-2021-37136
CVE-2021-37137
CVE-2021-43797
CVE-2021-21295
CVE-2021-21290
CVE-2014-0193

## Change:
updated `netty.version` from `4.1.16.Final` to `4.1.71.Final`