### PR TITLE
common fixes for guava_version_upgrade

### DIFF
--- a/common-cli/src/test/java/io/cdap/common/cli/CommandSetTest.java
+++ b/common-cli/src/test/java/io/cdap/common/cli/CommandSetTest.java
@@ -16,7 +16,6 @@
 
 package io.cdap.common.cli;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -26,6 +25,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 
 /**
@@ -270,7 +270,7 @@ public class CommandSetTest {
     PrintStream printStream = new PrintStream(outputStream);
     command.execute(args, printStream);
 
-    String output = new String(outputStream.toByteArray(), Charsets.UTF_8);
+    String output = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
     Assert.assertEquals(expectedOutput, output);
   }
 }

--- a/common-cli/src/test/java/io/cdap/common/cli/command/HelpCommandTest.java
+++ b/common-cli/src/test/java/io/cdap/common/cli/command/HelpCommandTest.java
@@ -17,7 +17,6 @@
 
 package io.cdap.common.cli.command;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import io.cdap.common.cli.Arguments;
 import io.cdap.common.cli.Command;
@@ -28,6 +27,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Tests for {@link HelpCommand}
@@ -155,7 +155,7 @@ public class HelpCommandTest {
     PrintStream printStream = new PrintStream(outputStream);
     command.execute(args, printStream);
 
-    String output = new String(outputStream.toByteArray(), Charsets.UTF_8);
+    String output = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
     Assert.assertEquals(expectedOutput, output);
   }
 }

--- a/common-core/src/main/java/io/cdap/common/Bytes.java
+++ b/common-core/src/main/java/io/cdap/common/Bytes.java
@@ -15,10 +15,10 @@
  */
 package io.cdap.common;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSortedMap;
 
 import java.io.DataOutput;
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
@@ -208,7 +208,7 @@ public class Bytes {
       return null;
     }
     buf.mark();
-    String s = Charsets.UTF_8.decode(buf).toString();
+    String s = StandardCharsets.UTF_8.decode(buf).toString();
     buf.reset();
     return s;
   }

--- a/common-core/src/main/java/io/cdap/common/ImmutablePair.java
+++ b/common-core/src/main/java/io/cdap/common/ImmutablePair.java
@@ -16,7 +16,9 @@
 
 package io.cdap.common;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
 
 /**
  * An {@link ImmutablePair} consists of two elements within. The elements once set
@@ -79,7 +81,7 @@ public final class ImmutablePair<A, B> {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
             .add("first", first)
             .add("second", second)
             .toString();
@@ -91,7 +93,7 @@ public final class ImmutablePair<A, B> {
    */
   @Override
   public int hashCode() {
-    return Objects.hashCode(first, second);
+    return Objects.hash(first, second);
   }
 
   /**
@@ -108,6 +110,6 @@ public final class ImmutablePair<A, B> {
       return false;
     }
     ImmutablePair<?, ?> other = (ImmutablePair<?, ?>) o;
-    return Objects.equal(first, other.first) && Objects.equal(second, other.second);
+    return Objects.equals(first, other.first) && Objects.equals(second, other.second);
   }
 }

--- a/common-core/src/main/java/io/cdap/common/Networks.java
+++ b/common-core/src/main/java/io/cdap/common/Networks.java
@@ -16,9 +16,8 @@
 
 package io.cdap.common;
 
-import com.google.common.base.Charsets;
-
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
@@ -93,6 +92,6 @@ public final class Networks {
     name = name.replace(':', '_');
     name = name.replace('/', '_');
 
-    return URLEncoder.encode(name, Charsets.UTF_8.name());
+    return URLEncoder.encode(name, StandardCharsets.UTF_8.name());
   }
 }

--- a/common-http/src/main/java/io/cdap/common/http/HttpRequest.java
+++ b/common-http/src/main/java/io/cdap/common/http/HttpRequest.java
@@ -16,11 +16,9 @@
 
 package io.cdap.common.http;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.io.InputSupplier;
 import io.cdap.common.ContentProvider;
 import io.cdap.common.io.ByteBufferInputStream;
 
@@ -32,6 +30,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -166,15 +165,6 @@ public class HttpRequest {
       return this;
     }
 
-    public Builder withBody(InputSupplier<? extends InputStream> body) {
-      return withBody(new ContentProvider<InputStream>() {
-        @Override
-        public InputStream getInput() throws IOException {
-          return body.getInput();
-        }
-      });
-    }
-
     public Builder withBody(ContentProvider<? extends InputStream> body) {
       this.body = body;
       this.bodyLength = null;
@@ -194,7 +184,7 @@ public class HttpRequest {
     }
 
     public Builder withBody(String body) {
-      return withBody(body, Charsets.UTF_8);
+      return withBody(body, StandardCharsets.UTF_8);
     }
 
     public Builder withBody(String body, Charset charset) {

--- a/common-http/src/main/java/io/cdap/common/http/HttpResponse.java
+++ b/common-http/src/main/java/io/cdap/common/http/HttpResponse.java
@@ -15,7 +15,6 @@
  */
 package io.cdap.common.http;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
@@ -30,6 +29,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.util.List;
@@ -123,7 +123,7 @@ public class HttpResponse {
   }
 
   public String getResponseBodyAsString() {
-    return getResponseBodyAsString(Charsets.UTF_8);
+    return getResponseBodyAsString(StandardCharsets.UTF_8);
   }
 
   public String getResponseBodyAsString(Charset charset) {
@@ -176,7 +176,8 @@ public class HttpResponse {
       }
       return ByteStreams.toByteArray(inputStream);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     } finally {
       closeQuietly(inputStream);
       inputStream = null;

--- a/common-http/src/main/java/io/cdap/common/http/ObjectResponse.java
+++ b/common-http/src/main/java/io/cdap/common/http/ObjectResponse.java
@@ -15,11 +15,11 @@
  */
 package io.cdap.common.http;
 
-import com.google.common.base.Charsets;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Convenient wrapper of {@link HttpResponse} that makes client code cleaner when dealing with java object that can be
@@ -35,7 +35,7 @@ public final class ObjectResponse<T> extends HttpResponse {
   @SuppressWarnings("unchecked")
   public static <T> ObjectResponse<T> fromJsonBody(HttpResponse response, Type typeOfObject, Gson gson) {
     T object = response.getResponseBody() == null ?
-      null : (T) gson.fromJson(new String(response.getResponseBody(), Charsets.UTF_8), typeOfObject);
+      null : (T) gson.fromJson(new String(response.getResponseBody(), StandardCharsets.UTF_8), typeOfObject);
     return new ObjectResponse<T>(response, object);
   }
 

--- a/common-http/src/test/java/io/cdap/common/http/HttpRequestsStreamTest.java
+++ b/common-http/src/test/java/io/cdap/common/http/HttpRequestsStreamTest.java
@@ -30,12 +30,12 @@ public class HttpRequestsStreamTest extends HttpRequestsTestBase {
   @Before
   public void setUp() throws Exception {
     httpService = new TestHttpService(false);
-    httpService.startAndWait();
+    httpService.startAsync().awaitRunning();
   }
 
   @After
   public void tearDown() {
-    httpService.stopAndWait();
+    httpService.stopAsync().awaitTerminated();
   }
 
   @Override

--- a/common-http/src/test/java/io/cdap/common/http/HttpRequestsTest.java
+++ b/common-http/src/test/java/io/cdap/common/http/HttpRequestsTest.java
@@ -33,12 +33,12 @@ public class HttpRequestsTest extends HttpRequestsTestBase {
   @Before
   public void setUp() throws Exception {
     httpService = new TestHttpService(false);
-    httpService.startAndWait();
+    httpService.startAsync().awaitRunning();
   }
 
   @After
   public void tearDown() {
-    httpService.stopAndWait();
+    httpService.stopAsync().awaitTerminated();
   }
 
   @Override

--- a/common-http/src/test/java/io/cdap/common/http/HttpRequestsTestBase.java
+++ b/common-http/src/test/java/io/cdap/common/http/HttpRequestsTestBase.java
@@ -16,7 +16,6 @@
 
 package io.cdap.common.http;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
@@ -409,14 +408,14 @@ public abstract class HttpRequestsTestBase {
     public void testPost(FullHttpRequest request,
                          HttpResponder responder) {
       responder.sendString(HttpResponseStatus.OK,
-                           request.content().toString(Charsets.UTF_8) + request.headers().get("sdf"));
+                           request.content().toString(StandardCharsets.UTF_8) + request.headers().get("sdf"));
     }
 
     @POST
     @Path("/testPost409")
     public void testPost409(FullHttpRequest request,
                             HttpResponder responder) {
-      responder.sendString(HttpResponseStatus.CONFLICT, request.content().toString(Charsets.UTF_8)
+      responder.sendString(HttpResponseStatus.CONFLICT, request.content().toString(StandardCharsets.UTF_8)
         + request.headers().get("sdf") + "409");
     }
 
@@ -424,7 +423,7 @@ public abstract class HttpRequestsTestBase {
     @Path("/testPut")
     public void testPut(FullHttpRequest request,
                         HttpResponder responder) {
-      responder.sendString(HttpResponseStatus.OK, request.content().toString(Charsets.UTF_8)
+      responder.sendString(HttpResponseStatus.OK, request.content().toString(StandardCharsets.UTF_8)
         + request.headers().get("sdf"));
     }
 
@@ -432,7 +431,7 @@ public abstract class HttpRequestsTestBase {
     @Path("/testPut409")
     public void testPut409(FullHttpRequest request,
                            HttpResponder responder) {
-      responder.sendString(HttpResponseStatus.CONFLICT, request.content().toString(Charsets.UTF_8)
+      responder.sendString(HttpResponseStatus.CONFLICT, request.content().toString(StandardCharsets.UTF_8)
         + request.headers().get("sdf") + "409");
     }
 

--- a/common-http/src/test/java/io/cdap/common/http/HttpsRequestsTest.java
+++ b/common-http/src/test/java/io/cdap/common/http/HttpsRequestsTest.java
@@ -33,12 +33,12 @@ public class HttpsRequestsTest extends HttpRequestsTestBase {
   @Before
   public void setUp() throws Exception {
     httpsService = new TestHttpService(true);
-    httpsService.startAndWait();
+    httpsService.startAsync().awaitRunning();
   }
 
   @After
   public void tearDown() {
-    httpsService.stopAndWait();
+    httpsService.stopAsync().awaitTerminated();
   }
 
   @Override

--- a/common-http/src/test/java/io/cdap/common/http/TestHttpService.java
+++ b/common-http/src/test/java/io/cdap/common/http/TestHttpService.java
@@ -16,7 +16,7 @@
 
 package io.cdap.common.http;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.AbstractIdleService;
 import io.cdap.http.ChannelPipelineModifier;
 import io.cdap.http.NettyHttpService;
@@ -90,7 +90,7 @@ public final class TestHttpService extends AbstractIdleService {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("bindAddress", httpService.getBindAddress())
       .toString();
   }

--- a/common-io/src/main/java/io/cdap/common/internal/io/ASMDatumWriterFactory.java
+++ b/common-io/src/main/java/io/cdap/common/internal/io/ASMDatumWriterFactory.java
@@ -16,7 +16,6 @@
 
 package io.cdap.common.internal.io;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -27,6 +26,7 @@ import io.cdap.common.internal.asm.ByteCodeClassLoader;
 import io.cdap.common.internal.asm.ClassDefinition;
 
 import java.util.Map;
+import java.util.Objects;
 import javax.inject.Inject;
 
 /**
@@ -61,7 +61,8 @@ public final class ASMDatumWriterFactory implements DatumWriterFactory {
       return (DatumWriter<T>) writerClass.getConstructor(Schema.class, FieldAccessorFactory.class)
                                         .newInstance(schema, fieldAccessorFactory);
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -121,7 +122,7 @@ public final class ASMDatumWriterFactory implements DatumWriterFactory {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(schema, type);
+      return Objects.hash(schema, type);
     }
   }
 }

--- a/common-io/src/main/java/io/cdap/common/internal/io/DatumWriterGenerator.java
+++ b/common-io/src/main/java/io/cdap/common/internal/io/DatumWriterGenerator.java
@@ -795,7 +795,8 @@ final class DatumWriterGenerator {
         mg.invokeVirtual(classType, getEncodeMethod(fieldType, field.getSchema()));
       }
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/common-io/src/main/java/io/cdap/common/internal/io/FieldAccessorGenerator.java
+++ b/common-io/src/main/java/io/cdap/common/internal/io/FieldAccessorGenerator.java
@@ -117,7 +117,8 @@ final class FieldAccessorGenerator {
 
        this.field = field;
      } catch (Exception e) {
-       throw Throwables.propagate(e);
+       Throwables.throwIfUnchecked(e);
+       throw new RuntimeException(e);
      }
     */
     Label beginTry = mg.newLabel();
@@ -149,7 +150,13 @@ final class FieldAccessorGenerator {
     mg.storeLocal(exception);
     mg.loadLocal(exception);
     mg.invokeStatic(Type.getType(Throwables.class),
-                    getMethod(RuntimeException.class, "propagate", Throwable.class));
+                    getMethod(void.class, "throwIfUnchecked", Throwable.class));
+    mg.loadLocal(exception);
+    mg.newInstance(Type.getType(RuntimeException.class));
+    mg.dupX1();
+    mg.swap();
+    mg.invokeConstructor(Type.getType(RuntimeException.class),
+                         getMethod(void.class, "<init>", Throwable.class));
     mg.throwException();
     mg.mark(endCatch);
   }
@@ -196,7 +203,8 @@ final class FieldAccessorGenerator {
      * try {
      *   // Call method
      * } catch (IllegalAccessException e) {
-     *   throw Throwables.propagate(e);
+     *   Throwables.throwIfUnchecked(e);
+     *   throw new RuntimeException(e);
      * }
      */
     Label beginTry = mg.newLabel();
@@ -215,7 +223,13 @@ final class FieldAccessorGenerator {
     mg.storeLocal(exception);
     mg.loadLocal(exception);
     mg.invokeStatic(Type.getType(Throwables.class),
-                    getMethod(RuntimeException.class, "propagate", Throwable.class));
+                    getMethod(void.class, "throwIfUnchecked", Throwable.class));
+    mg.loadLocal(exception);
+    mg.newInstance(Type.getType(RuntimeException.class));
+    mg.dupX1();
+    mg.swap();
+    mg.invokeConstructor(Type.getType(RuntimeException.class),
+                         getMethod(void.class, "<init>", Throwable.class));
     mg.throwException();
     mg.endMethod();
 

--- a/common-io/src/main/java/io/cdap/common/internal/io/FieldEntry.java
+++ b/common-io/src/main/java/io/cdap/common/internal/io/FieldEntry.java
@@ -16,8 +16,9 @@
 
 package io.cdap.common.internal.io;
 
-import com.google.common.base.Objects;
 import com.google.common.reflect.TypeToken;
+
+import java.util.Objects;
 
 /**
 *
@@ -54,6 +55,6 @@ final class FieldEntry {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(type, fieldName);
+    return Objects.hash(type, fieldName);
   }
 }

--- a/common-io/src/main/java/io/cdap/common/internal/io/ReflectionFieldAccessorFactory.java
+++ b/common-io/src/main/java/io/cdap/common/internal/io/ReflectionFieldAccessorFactory.java
@@ -60,7 +60,8 @@ public final class ReflectionFieldAccessorFactory implements FieldAccessorFactor
             try {
               finalField.set(object, value);
             } catch (Exception e) {
-              throw Throwables.propagate(e);
+              Throwables.throwIfUnchecked(e);
+              throw new RuntimeException(e);
             }
           }
 
@@ -70,7 +71,8 @@ public final class ReflectionFieldAccessorFactory implements FieldAccessorFactor
             try {
               return (T) finalField.get(object);
             } catch (Exception e) {
-              throw Throwables.propagate(e);
+              Throwables.throwIfUnchecked(e);
+              throw new RuntimeException(e);
             }
           }
 

--- a/common-io/src/main/java/io/cdap/common/internal/io/Schema.java
+++ b/common-io/src/main/java/io/cdap/common/internal/io/Schema.java
@@ -15,7 +15,6 @@
  */
 
 package io.cdap.common.internal.io;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.BiMap;
@@ -67,8 +66,8 @@ public final class Schema {
     }
 
     /**
-     * @return true if this enum represents a simple schema type.
-     */
+      * @return true if this enum represents a simple schema type.
+      */
     public boolean isSimpleType() {
       return simpleType;
     }
@@ -82,12 +81,12 @@ public final class Schema {
     private final Schema schema;
 
     /**
-     * Creates a {@link Field} instance with the given name and {@link Schema}.
-     *
-     * @param name Name of the field.
-     * @param schema Schema of the field.
-     * @return A new {@link Field} instance.
-     */
+      * Creates a {@link Field} instance with the given name and {@link Schema}.
+      *
+      * @param name Name of the field.
+      * @param schema Schema of the field.
+      * @return A new {@link Field} instance.
+      */
     public static Field of(String name, Schema schema) {
       return new Field(name, schema);
     }
@@ -98,15 +97,15 @@ public final class Schema {
     }
 
     /**
-     * @return Name of the field.
-     */
+      * @return Name of the field.
+      */
     public String getName() {
       return name;
     }
 
     /**
-     * @return Schema of the field.
-     */
+      * @return Schema of the field.
+      */
     public Schema getSchema() {
       return schema;
     }
@@ -640,7 +639,8 @@ public final class Schema {
       return builder.toString();
     } catch (IOException e) {
       // It should never throw IOException on the StringBuilder Writer, if it does, something very wrong.
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 }

--- a/common-io/src/main/java/io/cdap/common/internal/io/SchemaHash.java
+++ b/common-io/src/main/java/io/cdap/common/internal/io/SchemaHash.java
@@ -16,11 +16,11 @@
 
 package io.cdap.common.internal.io;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -93,7 +93,8 @@ public final class SchemaHash {
       MessageDigest md5 = updateHash(MessageDigest.getInstance("MD5"), schema, knownRecords);
       return md5.digest();
     } catch (NoSuchAlgorithmException e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -135,7 +136,7 @@ public final class SchemaHash {
       case ENUM:
         md5.update((byte) 8);
         for (String value : schema.getEnumValues()) {
-          md5.update(Charsets.UTF_8.encode(value));
+          md5.update(StandardCharsets.UTF_8.encode(value));
         }
         break;
       case ARRAY:
@@ -151,7 +152,7 @@ public final class SchemaHash {
         md5.update((byte) 11);
         boolean notKnown = knownRecords.add(schema.getRecordName());
         for (Schema.Field field : schema.getFields()) {
-          md5.update(Charsets.UTF_8.encode(field.getName()));
+          md5.update(StandardCharsets.UTF_8.encode(field.getName()));
           if (notKnown) {
             updateHash(md5, field.getSchema(), knownRecords);
           }

--- a/common-io/src/main/java/io/cdap/common/internal/io/TypeRepresentation.java
+++ b/common-io/src/main/java/io/cdap/common/internal/io/TypeRepresentation.java
@@ -16,7 +16,7 @@
 
 package io.cdap.common.internal.io;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -117,8 +117,8 @@ public final class TypeRepresentation implements ParameterizedType {
   @Override
   public Type getRawType() {
     try {
-      ClassLoader cl = Objects.firstNonNull(classLoader,
-                                            Objects.firstNonNull(Thread.currentThread().getContextClassLoader(),
+      ClassLoader cl = MoreObjects.firstNonNull(classLoader,
+                                            MoreObjects.firstNonNull(Thread.currentThread().getContextClassLoader(),
                                                                  getClass().getClassLoader()));
       return cl.loadClass(this.rawType);
     } catch (ClassNotFoundException e) {

--- a/common-io/src/main/java/io/cdap/common/io/BinaryDecoder.java
+++ b/common-io/src/main/java/io/cdap/common/io/BinaryDecoder.java
@@ -16,12 +16,11 @@
 
 package io.cdap.common.io;
 
-import com.google.common.base.Charsets;
-
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 /**
  * An {@link Decoder} for binary-format data.
@@ -88,7 +87,7 @@ public final class BinaryDecoder implements Decoder {
 
   @Override
   public String readString() throws IOException {
-    return new String(rawReadBytes(), Charsets.UTF_8);
+    return new String(rawReadBytes(), StandardCharsets.UTF_8);
   }
 
   @Override

--- a/common-io/src/main/java/io/cdap/common/io/BinaryEncoder.java
+++ b/common-io/src/main/java/io/cdap/common/io/BinaryEncoder.java
@@ -16,11 +16,10 @@
 
 package io.cdap.common.io;
 
-import com.google.common.base.Charsets;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 /**
  *  An {@link Encoder} for binary-format data.
@@ -112,7 +111,7 @@ public final class BinaryEncoder implements Encoder {
 
   @Override
   public Encoder writeString(String s) throws IOException {
-    return writeBytes(Charsets.UTF_8.encode(s));
+    return writeBytes(StandardCharsets.UTF_8.encode(s));
   }
 
   @Override

--- a/common-io/src/test/java/io/cdap/common/io/ASMDatumCodecTest.java
+++ b/common-io/src/test/java/io/cdap/common/io/ASMDatumCodecTest.java
@@ -16,7 +16,7 @@
 
 package io.cdap.common.io;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -270,7 +270,7 @@ public class ASMDatumCodecTest {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(i, s, list, e);
+      return Objects.hash(i, s, list, e);
     }
   }
 
@@ -356,7 +356,7 @@ public class ASMDatumCodecTest {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(data, left, right);
+      return Objects.hash(data, left, right);
     }
   }
 

--- a/common-lang/src/main/java/io/cdap/common/internal/lang/Reflections.java
+++ b/common-lang/src/main/java/io/cdap/common/internal/lang/Reflections.java
@@ -83,7 +83,8 @@ public final class Reflections {
         }
       }
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/common-lang/src/main/java/io/cdap/common/lang/ClassLoaders.java
+++ b/common-lang/src/main/java/io/cdap/common/lang/ClassLoaders.java
@@ -16,7 +16,7 @@
 
 package io.cdap.common.lang;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import javax.annotation.Nullable;
 
@@ -39,7 +39,7 @@ public final class ClassLoaders {
    */
   public static Class<?> loadClass(String className, @Nullable ClassLoader classLoader,
                                    Object caller) throws ClassNotFoundException {
-    ClassLoader cl = Objects.firstNonNull(classLoader, caller.getClass().getClassLoader());
+    ClassLoader cl = MoreObjects.firstNonNull(classLoader, caller.getClass().getClassLoader());
     return cl.loadClass(className);
   }
 

--- a/common-lang/src/main/java/io/cdap/common/lang/DirectoryClassLoader.java
+++ b/common-lang/src/main/java/io/cdap/common/lang/DirectoryClassLoader.java
@@ -72,7 +72,8 @@ public class DirectoryClassLoader extends URLClassLoader {
     } catch (MalformedURLException e) {
       // Should never happen
       LOG.error("Error in adding jar URLs to classPathUrls", e);
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/common-lang/src/main/java/io/cdap/common/lang/InstantiatorFactory.java
+++ b/common-lang/src/main/java/io/cdap/common/lang/InstantiatorFactory.java
@@ -102,7 +102,8 @@ public final class InstantiatorFactory {
           try {
             return (T) defaultCons.newInstance();
           } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
           }
         }
       };
@@ -183,7 +184,8 @@ public final class InstantiatorFactory {
           Reflections.visit(instance, type, new FieldInitializer());
           return (T) instance;
         } catch (InstantiationException e) {
-          throw Throwables.propagate(e);
+          Throwables.throwIfUnchecked(e);
+          throw new RuntimeException(e);
         }
       }
     };

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@ the License.
     <asm.version>7.1</asm.version>
     <findbugs.jsr305.version>2.0.1</findbugs.jsr305.version>
     <geronimo.version>2.0.0</geronimo.version>
-    <guava.version>13.0.1</guava.version>
+    <guava.version>32.0.0-jre</guava.version>
     <guice.version>4.0</guice.version>
     <gson.version>2.2.4</gson.version>
     <netty.http.version>1.5.0</netty.http.version>


### PR DESCRIPTION
Replace removed APIs:

Throwables.propagate() -> throw new RuntimeException(e)
InputSupplier (removed) -> use existing ContentProvider
Charsets.UTF_8 -> StandardCharsets.UTF_8
Objects.toStringHelper/firstNonNull -> MoreObjects equivalents
Objects.hashCode -> java.util.Objects.hash
startAndWait/stopAndWait -> startAsync().awaitRunning/stopAsync().awaitTerminated
Update ASM bytecode generation to use RuntimeException constructor
Fix header ordering in HttpRequestsTestBase